### PR TITLE
Make repo binder-ready (on-hold)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,4 @@
+channels:
+    - conda-forge
+dependencies:
+    - jupyter-server-proxy=1.5.0=py_0

--- a/notebooks/templates/example.jl
+++ b/notebooks/templates/example.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.12.4
+# v0.12.11
 
 using Markdown
 using InteractiveUtils

--- a/notebooks/templates/example.jl
+++ b/notebooks/templates/example.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.12.11
+# v0.12.12
 
 using Markdown
 using InteractiveUtils

--- a/notebooks/templates/template.jl
+++ b/notebooks/templates/template.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.12.4
+# v0.12.11
 
 using Markdown
 using InteractiveUtils

--- a/notebooks/templates/template.jl
+++ b/notebooks/templates/template.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.12.11
+# v0.12.12
 
 using Markdown
 using InteractiveUtils

--- a/plutoserver.py
+++ b/plutoserver.py
@@ -1,0 +1,8 @@
+def setup_plutoserver():
+  return {
+    "command": ["julia", "--optimize=0", "-e", "import Pluto; Pluto.run(host=\"0.0.0.0\", port={port}, launch_browser=false, require_secret_for_open_links=false, require_secret_for_access=false)"],
+    "timeout": 60,
+    "launcher_entry": {
+        "title": "Pluto.jl",
+    },
+  }

--- a/plutoserver.py
+++ b/plutoserver.py
@@ -1,6 +1,6 @@
 def setup_plutoserver():
   return {
-    "command": ["julia", "--optimize=0", "-e", "import Pluto; Pluto.run(host=\"0.0.0.0\", port={port}, launch_browser=false, require_secret_for_open_links=false, require_secret_for_access=false)"],
+    "command": ["julia", "--optimize=0", "-e","import Pkg; Pkg.add(\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\")" ,"import Pluto; Pluto.run(host=\"0.0.0.0\", port={port}, launch_browser=false, require_secret_for_open_links=false, require_secret_for_access=false)"],
     "timeout": 60,
     "launcher_entry": {
         "title": "Pluto.jl",

--- a/plutoserver.py
+++ b/plutoserver.py
@@ -1,6 +1,6 @@
 def setup_plutoserver():
   return {
-    "command": ["julia", "--optimize=0", "-e","import Pkg; Pkg.add(\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\")" ,"import Pluto; Pluto.run(host=\"0.0.0.0\", port={port}, launch_browser=false, require_secret_for_open_links=false, require_secret_for_access=false)"],
+    "command": ["julia", "--optimize=0", "-e","import Pkg; Pkg.add(\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\");" ,"import Pluto; Pluto.run(host=\"0.0.0.0\", port={port}, launch_browser=false, require_secret_for_open_links=false, require_secret_for_access=false)"],
     "timeout": 60,
     "launcher_entry": {
         "title": "Pluto.jl",

--- a/plutoserver.py
+++ b/plutoserver.py
@@ -1,6 +1,6 @@
 def setup_plutoserver():
   return {
-    "command": ["julia", "--optimize=0", "-e","import Pkg; Pkg.add(\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\");" ,"import Pluto; Pluto.run(host=\"0.0.0.0\", port={port}, launch_browser=false, require_secret_for_open_links=false, require_secret_for_access=false)"],
+    "command": ["julia", "--optimize=0", "-e" ,"import Pluto; Pluto.run(host=\"0.0.0.0\", port={port}, launch_browser=false, require_secret_for_open_links=false, require_secret_for_access=false)"],
     "timeout": 60,
     "launcher_entry": {
         "title": "Pluto.jl",

--- a/postBuild
+++ b/postBuild
@@ -1,5 +1,4 @@
 #!/bin/bash
-mkdir /srv/julia/dev
-git clone -b DS-Julia-2925 git@github.com:Beramos/Pluto.jl.git /srv/julia/dev/.
+julia -e "import Pkg; add https://github.com/Beramos/Pluto.jl#DS-Julia-2925"
 
 

--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
 #!/bin/bash
-julia -e "import Pkg; Pkg.rm(\"Pluto\"); Pkg.add(\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\")"
+julia -e "import Pkg; Pkg.rm(\"Pluto\"); Pkg.add(url=\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\")"
 
 

--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
 #!/bin/bash
-julia -e "import Pkg; Pkg.rm(\"Pluto\"); Pkg.add(url=\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\")"
+julia -e "import Pkg; Pkg.rm(\"Pluto\"); Pkg.add(PackageSpec(url=\"https://github.com/Beramos/Pluto.jl\", rev=\"DS-Julia-2925\"))"
 
 

--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
 #!/bin/bash
-julia -e "import Pkg; Pkg.rm(\"Pluto\"); Pkg.add(PackageSpec(url=\"https://github.com/Beramos/Pluto.jl\", rev=\"DS-Julia-2925\"))"
+julia -e "import Pkg; Pkg.rm(\"Pluto\"); Pkg.add(url=\"https://github.com/Beramos/Pluto.jl\", rev=\"DS-Julia-2925\")"
 
 

--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
 #!/bin/bash
-julia -e "import Pkg; add https://github.com/Beramos/Pluto.jl#DS-Julia-2925"
+julia -e "import Pkg; Pkg.rm(\"Pluto\"); Pkg.add(\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\")"
 
 

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,5 @@
+#!/bin/bash
+mkdir /srv/julia/dev
+git clone -b DS-Julia-2925 git@github.com:Beramos/Pluto.jl.git /srv/julia/dev/.
+
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+import setuptools
+
+setuptools.setup(
+  name="jupyter-pluto-proxy",
+  # py_modules rather than packages, since we only have 1 file
+  py_modules=['plutoserver'],
+  entry_points={
+      'jupyter_serverproxy_servers': [
+          # name = packagename:function_name
+          'pluto = plutoserver:setup_plutoserver',
+      ]
+  },
+  install_requires=['jupyter-server-proxy'],
+)
+
+# because this is a demo of Pluto, we add some popular packages to the global package env and precompile
+import os
+os.system('julia -e "import Pkg; Pkg.add([\\"DataFrames\\", \\"CSV\\", \\"Plots\\"]); Pkg.precompile()"')

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,4 @@ setuptools.setup(
 
 # because this is a demo of Pluto, we add some popular packages to the global package env and precompile
 import os
-os.system('julia -e "import Pkg; Pkg.add([\\"DataFrames\\", \\"CSV\\", \\"Plots\\"]); Pkg.precompile()"')
+os.system('julia -e "import Pkg; Pkg.add([\\"DataFrames\\", \\"CSV\\", \\"Plots\\", \\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\\"]); Pkg.precompile()"')

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,4 @@ setuptools.setup(
 
 # because this is a demo of Pluto, we add some popular packages to the global package env and precompile
 import os
-os.system('julia -e "import Pkg; Pkg.add([\\"DataFrames\\", \\"CSV\\", \\"Plots\\", \\"https://github.com/Beramos/Pluto.jl#DS-Julia-2925\\"]); Pkg.precompile()"')
+os.system('julia -e "import Pkg; Pkg.add([\\"DataFrames\\", \\"CSV\\", \\"Plots\\"]); Pkg.precompile()"')


### PR DESCRIPTION
It was quite a quest but I don't like the lacking tree feature in Pluto where you have a clear overview of the notebooks like in Jupyter. I discussed this is #8. 

It is a little hacky but I forked pluto and made a custom homepage for the course [temporary link](https://mybinder.org/v2/gh/beramos/DS-Julia2925/binder_pluto_server?urlpath=pluto).

![image](https://user-images.githubusercontent.com/11618908/100597383-afa6f000-32fd-11eb-95e7-e7f1e7720479.png)

I configured binder to load [my fork](https://github.com/Beramos/Pluto.jl/tree/DS-Julia-2925) of the Pluto package.

There are still a lot of possible optimisations which I did not perform to save some time.
- We need to manually add the notebooks to the homepage before course launch.
- The binder startup seems to be very slow but this should improve once binder keeps an image of the docker.
- There are options to precompile the environment for faster binder start-up speed. [https://github.com/fonsp/PlutoUtils.jl/issues/20
](https://github.com/fonsp/PlutoUtils.jl/issues/20
)

However, since we do not actually want our students to be working in binder, I think after adding all the available notebooks, we can close this PR.
