### PR TITLE
Environment misery fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,7 @@ to install the dependencies.
 Open the Julia REPL
 
 ```julia
-import Pkg
-Pkg.activate(".")
-
-using Pluto
-Pluto.run()
+julia launcher.jl
 ```
 
 This should open a browser window with the Pluto notebooks.

--- a/launch.jl
+++ b/launch.jl
@@ -1,0 +1,15 @@
+#=
+Created on Tuesday 15 December 2020
+Last update: -
+
+@author: Bram De Jaegher
+bram.de.jaegher@gmail.com
+
+Launches the Pluto notebooks for the project
+=#
+
+cd("notebooks")
+import Pkg; Pkg.activate(".")
+
+using Pluto
+Pluto.run()

--- a/notebooks/Project.toml
+++ b/notebooks/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"


### PR DESCRIPTION
After our discussion @MichielStock, I decided to add a specific environment for the notebooks. Since I really have dependency problems with adding packages to the default V1.X environment. I also don't like the idea of not using a different environment for each project.
With this PR it should be still possible to use the former approach.

There are now two environments:
- ./project.toml  -> for the DSJulia package
- ./notebooks/project.toml -> for the Pluto notebooks


