### PR TITLE
Fixing the annoying default values for the Question block

### DIFF
--- a/src/grading.jl
+++ b/src/grading.jl
@@ -28,8 +28,12 @@ accept!(t::ProgressTracker) =	t.correct += 1
 Base.show(io::IO, t::ProgressTracker) = print(io, "Notebook of **$(t.name)** with a completion of **$(t.correct) out of $(t.total)** question(s).")
 
 function check_answer(q::Question,  t::ProgressTracker)
-	addQuestion!(t)
 	validators = q.validators
+	if length(validators) < 1
+		return md""
+	end
+
+	addQuestion!(t)
 	all_valid = all(validators)
 	some_valid = any(validators)
 	if ismissing(all_valid) 

--- a/src/question.jl
+++ b/src/question.jl
@@ -181,7 +181,7 @@ function tohtml(q::QuestionBlock)
 end
 
 
-u# --- Macro(s) --- #
+# --- Macro(s) --- #
 """
 The @safe macro is a hidden try-catch statement to avoid the Markdown admonitions to crash when
 the user introduces an error in the exercise functions.

--- a/src/question.jl
+++ b/src/question.jl
@@ -32,9 +32,9 @@ mutable struct Question <: AbstractQuestion
 	validators::Any
 	status::Markdown.MD
 
-	Question(;description=description_default, 
-						validators=[missing], 
-						status=still_missing()) = new(description, validators, status)
+	Question(;description=md"", 
+						validators=[], 
+						status=md"") = new(description, validators, status)
 end
 
 """
@@ -58,9 +58,9 @@ mutable struct QuestionOptional{T<:AbstractDifficulty}  <: AbstractQuestion
 	status::Markdown.MD
 	difficulty::T
 
-	QuestionOptional{T}(;description=description_default, 
-						validators=[missing], 
-						status=still_missing()) where {T<:AbstractDifficulty} = new{T}(description, validators, status, T())
+	QuestionOptional{T}(;description=md"", 
+						validators=[], 
+						status=md"") where {T<:AbstractDifficulty} = new{T}(description, validators, status, T())
 end
 
 """
@@ -124,7 +124,7 @@ mutable struct QuestionBlock <: AbstractQuestionBlock
 	hints::Array{Markdown.MD}
 	questions::Array{T} where {T<:AbstractQuestion}
 
-	QuestionBlock(;title=title_default,
+	QuestionBlock(;title=md"",
 									description=md"",
 									hints = Markdown.MD[],
 									questions = [Question()]) = new(title, description, hints, questions) 
@@ -179,13 +179,6 @@ function tohtml(q::QuestionBlock)
 	"""
 	return out
 end
-
-
-# --- Defaults --- #
-title_default = Markdown.MD(md"### Question 0.: /insert title here/")
-description_default = Markdown.MD(md"""Complete the function `myclamp(x)` that clamps a number `x` between 0 and 1.
-Open assignments always return `missing`.
-""")
 
 
 # --- Macro(s) --- #

--- a/src/question.jl
+++ b/src/question.jl
@@ -181,7 +181,7 @@ function tohtml(q::QuestionBlock)
 end
 
 
-# --- Macro(s) --- #
+u# --- Macro(s) --- #
 """
 The @safe macro is a hidden try-catch statement to avoid the Markdown admonitions to crash when
 the user introduces an error in the exercise functions.
@@ -207,7 +207,9 @@ function check_answer(q::AbstractQuestion)
 	validators = q.validators
 	all_valid = all(validators)
 	some_valid = any(validators)
-	if ismissing(all_valid) 
+
+	if length(validators) < 1 && return md""
+	elseif ismissing(all_valid) 
 		status = still_missing()
 	elseif some_valid && !all_valid
 		status = keep_working()


### PR DESCRIPTION
- default values to empty md""
- validators do not force status blocks to questions without validators
- It is now easy to have questions, both optional and mandatory without validators

![image](https://user-images.githubusercontent.com/11618908/105024104-fd152300-5a4b-11eb-9556-3e8e6c52f64b.png)
