### PR TITLE
Setup julia911 (julia emergency machines)

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,48 @@
+# DS-Julia2925 Ops scripts
+This folder contains operational scripts to automate the setup and management of a remote Julia/Pluto server for the Julia2925 course.
+
+## 1. setup-remote.sh
+Purpose:
+Automates the installation and configuration of a Julia environment (with Pluto.jl) on a remote Debian 12 server.
+It creates a user, installs Julia, sets up Pluto as a systemd service, and copies course notebooks and examples.
+
+**Usage:** ``` ./setup-remote.sh [OPTIONS] SERVER_ADDRESS [NEW_USERNAME] ```
+
+**Options:**
+
+-h, --help Show help message
+-k, --ssh-key PATH Path to public SSH key to add to the new user (optional)
+-v, --julia-version VER Julia version to install (default: 1.11.5)
+**Arguments:**
+
+SERVER_ADDRESS Address of the server to connect to (required)
+NEW_USERNAME Username to create (default: user)
+Example: ``` ./setup-remote.sh -k ~/.ssh/id_rsa.pub -v 1.11.5 example.com juliauser ./setup-remote.sh example.com ```
+
+**What it does:**
+
+- Connects to the remote server as root.
+- Creates a new user (or uses the default user).
+- Optionally sets up SSH key authentication.
+- Installs Julia and Pluto.
+- Copies the notebooks and examples folders to the user's home.
+- Configures Pluto to run as a systemd service, accessible on port 1234.
+
+## 2. check-secret-remote.sh
+**Purpose:**
+Fetches the secret URL for the running Pluto server from the remote machine's systemd logs.
+
+**Usage:** ``` check-secret-remote.sh SERVER_ADDRESS ```
+
+**Example:** ``` check-secret-remote.sh example.com ```
+
+What it does:
+
+- Connects to the remote server via SSH.
+- Reads the last 100 lines of the Pluto systemd service logs.
+- Extracts and prints the Pluto access URL (including the secret token) in a user-friendly, colored format.
+
+**Note:**
+Make sure your remote server allows SSH root login and has outbound internet access.
+The scripts are designed to be idempotent and safe to re-run.
+For best results, run these scripts from the root of the course repository so the notebooks and examples folders are found.

--- a/ops/README.md
+++ b/ops/README.md
@@ -10,7 +10,19 @@ This setup was tested with scaleway's `PRO2-XXS` machine with the following spec
 - 2 *CPUs*
 - 8Gb *RAM*
 - 350Mbs *Bandwidth*
-- 10Gb *block storage* 
+- 10Gb *block storage*
+- Flexible IPv4 address
+
+and these security policies,
+
+**inbound:**
+- default: drop all
+- accept port 80, 432 on 0.0.0.0/0
+- accept port 22, on specified machines *(need to add manually)*
+   
+**outbound:**
+- default: accept all
+- drop port 25, 465, 587, for 0.0.0.0/0 and ::/0
 
 **Usage:** ``` ./setup-remote.sh [OPTIONS] SERVER_ADDRESS [NEW_USERNAME] ```
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -17,12 +17,12 @@ and these security policies,
 
 **inbound:**
 - default: drop all
-- accept port 80, 432 on 0.0.0.0/0
+- accept port 80, 432, 1234 on 0.0.0.0/0
 - accept port 22, on specified machines *(need to add manually)*
    
 **outbound:**
 - default: accept all
-- drop port 25, 465, 587, for 0.0.0.0/0 and ::/0
+- drop port 25, 465, 587, for 0.0.0.0/0 and ::/0x
 
 **Usage:** ``` ./setup-remote.sh [OPTIONS] SERVER_ADDRESS [NEW_USERNAME] ```
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -6,6 +6,12 @@ Purpose:
 Automates the installation and configuration of a Julia environment (with Pluto.jl) on a remote Debian 12 server.
 It creates a user, installs Julia, sets up Pluto as a systemd service, and copies course notebooks and examples.
 
+This setup was tested with scaleway's `PRO2-XXS` machine with the following specs:
+- 2 *CPUs*
+- 8Gb *RAM*
+- 350Mbs *Bandwidth*
+- 10Gb *block storage* 
+
 **Usage:** ``` ./setup-remote.sh [OPTIONS] SERVER_ADDRESS [NEW_USERNAME] ```
 
 **Options:**

--- a/ops/check-secret-remote.sh
+++ b/ops/check-secret-remote.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# filepath: /home/bramdj/Desktop/git/DS-Julia2925/ops/check-secret-remote.sh
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 SERVER_ADDRESS"
+  exit 1
+fi
+
+SERVER_ADDRESS="$1"
+
+echo -e "\033[1;34m🔍 Connecting to $SERVER_ADDRESS to check Pluto service secret...\033[0m"
+
+# Get the last 100 lines of the Pluto service log and search for the URL with the secret
+URL_LINE=$(ssh root@"$SERVER_ADDRESS" "journalctl -u pluto-server -n 100 --no-pager | grep -oE 'http://[0-9.:]+:1234/\?secret=[A-Za-z0-9]+' | tail -1")
+
+if [[ -n "$URL_LINE" ]]; then
+  # Replace 0.0.0.0 or 127.0.0.1 or localhost with the actual server address
+  DISPLAY_URL=$(echo "$URL_LINE" | sed -E "s#(http://)(0\.0\.0\.0|127\.0\.0\.1|localhost)#\1$SERVER_ADDRESS#")
+  echo -e "\033[1;32m✅ Found Pluto URL:\033[0m"
+  echo -e "\033[1;33m$DISPLAY_URL\033[0m"
+  echo -e "\033[1;36mOpen this URL in your browser to access Pluto.\033[0m"
+else
+  echo -e "\033[1;31m❌ Could not find Pluto URL with secret in the service logs.\033[0m"
+  echo "Try restarting the service or wait a few seconds and try again."
+fi

--- a/ops/setup-remote.sh
+++ b/ops/setup-remote.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+set -e
+
+# Default values
+JULIA_VERSION="1.11.5"
+SSH_KEY_PATH=""
+DEFAULT_USERNAME="user"
+
+# Help function
+show_help() {
+    echo "Usage: $0 [OPTIONS] SERVER_ADDRESS [NEW_USERNAME]"
+    echo ""
+    echo "Options:"
+    echo "  -h, --help                 Show this help message"
+    echo "  -k, --ssh-key PATH         Path to public SSH key to add to the new user (optional)"
+    echo "  -v, --julia-version VER    Julia version to install (default: $JULIA_VERSION)"
+    echo ""
+    echo "Arguments:"
+    echo "  SERVER_ADDRESS             Address of the server to connect to (required)"
+    echo "  NEW_USERNAME               Username to create (default: $DEFAULT_USERNAME)"
+    echo ""
+    echo "Example:"
+    echo "  $0 -k ~/.ssh/id_rsa.pub -v 1.11.5 example.com newuser"
+    echo "  $0 example.com             # Creates default user '$DEFAULT_USERNAME'"
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        -k|--ssh-key)
+            SSH_KEY_PATH="$2"
+            shift 2
+            ;;
+        -v|--julia-version)
+            JULIA_VERSION="$2"
+            shift 2
+            ;;
+        *)
+            if [[ -z "$SERVER_ADDRESS" ]]; then
+                SERVER_ADDRESS="$1"
+                shift
+            elif [[ -z "$NEW_USERNAME" ]]; then
+                NEW_USERNAME="$1"
+                shift
+            else
+                echo "Error: Unknown parameter: $1"
+                show_help
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+# Set default username if not provided
+if [[ -z "$NEW_USERNAME" ]]; then
+    NEW_USERNAME="$DEFAULT_USERNAME"
+    echo "No username specified, using default: $NEW_USERNAME"
+fi
+
+# Validate required parameters
+if [[ -z "$SERVER_ADDRESS" && -z "$REMOTE_EXECUTION" ]]; then
+  echo "Error: SERVER_ADDRESS is required."
+  show_help
+  exit 1
+fi
+
+# Check if SSH key exists if specified
+if [[ -n "$SSH_KEY_PATH" && ! -f "$SSH_KEY_PATH" ]]; then
+    echo "Error: SSH key file not found: $SSH_KEY_PATH"
+    exit 1
+fi
+
+# Determine if running locally or on remote server
+if [[ -z "$REMOTE_EXECUTION" ]]; then
+    # Running locally - prepare to copy to server and execute
+    
+    # Encode SSH key content if provided
+    SSH_KEY_CONTENT=""
+    if [[ -n "$SSH_KEY_PATH" ]]; then
+        SSH_KEY_CONTENT=$(cat "$SSH_KEY_PATH" | base64 -w 0)
+    fi
+    
+    echo "Connecting to server $SERVER_ADDRESS..."
+    # Copy this script to the server
+    scp "$0" "root@$SERVER_ADDRESS:/tmp/setup_julia_pluto.sh"
+    
+    # Execute the script on the remote server
+    echo "Executing setup on server..."
+    ssh "root@$SERVER_ADDRESS" "chmod +x /tmp/setup_julia_pluto.sh && REMOTE_EXECUTION=1 NEW_USERNAME='$NEW_USERNAME' JULIA_VERSION='$JULIA_VERSION' SSH_KEY_CONTENT='$SSH_KEY_CONTENT' /tmp/setup_julia_pluto.sh"
+    
+    echo "Setup completed successfully!"
+    echo "Access Pluto at http://$SERVER_ADDRESS:1234/"
+    exit 0
+else
+    # Rest of the script remains the same...
+    # Running on remote server - perform setup
+    echo "Running setup on server..."
+    
+    # Create the user with home directory
+    echo "Creating user: $NEW_USERNAME"
+    useradd -m -s /bin/bash "$NEW_USERNAME"
+    # Generate a random password
+    RANDOM_PASSWORD=$(openssl rand -base64 12)
+    echo "$NEW_USERNAME:$RANDOM_PASSWORD" | chpasswd
+    echo "User created with password: $RANDOM_PASSWORD"
+    
+    # Set up SSH key if provided
+    if [[ -n "$SSH_KEY_CONTENT" ]]; then
+        echo "Setting up SSH key for $NEW_USERNAME"
+        mkdir -p /home/$NEW_USERNAME/.ssh
+        echo "$SSH_KEY_CONTENT" | base64 -d > /home/$NEW_USERNAME/.ssh/authorized_keys
+        chmod 700 /home/$NEW_USERNAME/.ssh
+        chmod 600 /home/$NEW_USERNAME/.ssh/authorized_keys
+        chown -R $NEW_USERNAME:$NEW_USERNAME /home/$NEW_USERNAME/.ssh
+    fi
+    
+    # Install Julia
+    echo "Installing Julia..."
+    su - $NEW_USERNAME -c "curl -fsSL https://install.julialang.org | sh"
+    
+    # Add specified Julia version using juliaup
+    echo "Adding Julia version $JULIA_VERSION..."
+    su - $NEW_USERNAME -c "source ~/.bashrc && juliaup add $JULIA_VERSION"
+    su - $NEW_USERNAME -c "source ~/.bashrc && juliaup default $JULIA_VERSION"
+    
+    # Create startPluto.jl
+    echo "Creating startPluto.jl..."
+    cat << 'EOF' > /home/$NEW_USERNAME/startPluto.jl
+using Pluto
+Pluto.run(host="0.0.0.0")
+EOF
+    chown $NEW_USERNAME:$NEW_USERNAME /home/$NEW_USERNAME/startPluto.jl
+    
+    # Install Pluto
+    echo "Installing Pluto..."
+    su - $NEW_USERNAME -c "source ~/.bashrc && julia -e 'using Pkg; Pkg.add(\"Pluto\")'"
+    
+    # Find julia path
+    JULIA_PATH=$(su - $NEW_USERNAME -c "source ~/.bashrc && which julia")
+    if [[ -z "$JULIA_PATH" ]]; then
+        # Fallback path
+        if [[ -f /home/$NEW_USERNAME/.juliaup/bin/julia ]]; then
+            JULIA_PATH="/home/$NEW_USERNAME/.juliaup/bin/julia"
+        else
+            echo "Warning: Could not find Julia executable. Using 'julia' in PATH."
+            JULIA_PATH="julia"
+        fi
+    fi
+    
+    # Create systemd service file
+    echo "Creating systemd service for Pluto..."
+    cat << EOF > /etc/systemd/system/pluto-server.service
+[Unit]
+Description=Pluto Notebook Server
+After=network.target
+
+[Service]
+Type=simple
+User=$NEW_USERNAME
+WorkingDirectory=/home/$NEW_USERNAME
+ExecStart=$JULIA_PATH /home/$NEW_USERNAME/startPluto.jl
+Restart=on-failure
+Environment=PATH=/home/$NEW_USERNAME/.juliaup/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    
+    # Reload systemd, enable and start the service
+    systemctl daemon-reload
+    systemctl enable pluto-server
+    systemctl start pluto-server
+    
+    # Display service status
+    echo "Checking service status..."
+    systemctl status pluto-server --no-pager
+    
+    echo "✅ Setup complete!"
+    echo "Pluto server is now running and configured to start on boot"
+    echo "You can access it at http://SERVER_IP:1234/"
+    
+    exit 0
+fi


### PR DESCRIPTION
closes #179 

This was fun! I vibe-coded this one. 

In case someone is unable to run julia on their laptop I have setup a script that installs everything on a scaleway instance (debian 12).
It moves the notebooks to that machine installs julia, runs the Pluto server and Pluto will be reachable on the web. The nice things is that you need a secret to access it so it is quite safe since you need SSH access to the machine to get this secret (that is what the `check-secret-remote.sh`-script does. If we have technical users it even creates an account on the machine so they can SSH into it.

I've tested the setup with a 10Gb ROM, 8Gb RAM and 2CPU machine and it seems to work fast enough. Estimated cost: €1.2/instance/day so that is a no-brainer. 

 